### PR TITLE
Rust can task

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,3 +19,4 @@ rustflags = ["-Z", "dwarf-version=4"]
 
 [registries]
 htc-cargo-index = { index = "https://github.com/hightec-rt/htc-cargo-index" }
+bluewind = { index = "https://github.com/bluewind-embedded-systems/bw-cargo-index" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ pxros-hr = { version = "0.2.0", registry = "htc-cargo-index" }
 
 veecle-pxros = { path = "." }
 
+bw-r-drivers-tc37x = { git = "https://github.com/bluewind-embedded-systems/bw-r-drivers-tc37x.git", branch = "main" }
+
 # Abort on panic since this is the default behavior on our intended target.
 [profile.dev]
 panic = "abort"

--- a/app-tc37x/bsp/uc/bsp_uc.c
+++ b/app-tc37x/bsp/uc/bsp_uc.c
@@ -920,6 +920,8 @@ void bsp_uc_InitClock(void)
     con1.U = SCU_CCUCON1.U;
     con1.B.QSPIDIV = UC_CCU_QSPI_DIV;
     con1.B.CLKSELQSPI = UC_CCU_QSPI_CLKSEL;
+    con1.B.MCANDIV = UC_CCU_MCAN_DIV;
+    con1.B.CLKSELMCAN = UC_CCU_MCAN_CLKSEL;
     bsp_uc_scu_SetCcuCon(&SCU_CCUCON1.U, con1.U, 1);
 
     /* Flash modules - timing */

--- a/app-tc37x/bsp/uc/uc_tc37/uc_tc37_spec.h
+++ b/app-tc37x/bsp/uc/uc_tc37/uc_tc37_spec.h
@@ -74,6 +74,7 @@
 
 /* Peripheral clocks needed in BSP example */
 #define UC_QSPI_CLOCK             200 /* MAX=200; source = fPLL1 | fPLL2 | fBACK */
+#define UC_MCAN_CLOCK             80  /* source = fPLL1 | fPLL1/2 | fBACK */
 #define UC_STM_CLOCK              100 /* MAX=100; source = fPLL0 | fBACK */
 
 /* BSP supportive time macros */
@@ -272,6 +273,12 @@
 #define UC_CCU_QSPI_CLKSEL        2 /* fPLL2 use as clock source for fSOURCEQSPI */
 #if ((UC_CCU_QSPI_DIV * UC_QSPI_CLOCK) != UC_PLL2_CLOCK)
 #error Wrong QSPI clock setting, not a whole number divider
+#endif
+
+#define UC_CCU_MCAN_DIV           ((UC_PLL1_CLOCK/2) / UC_MCAN_CLOCK)
+#define UC_CCU_MCAN_CLKSEL        1 /* fMCANI is used as clock source fMCAN */
+#if ((UC_CCU_MCAN_DIV * UC_MCAN_CLOCK) != (UC_PLL1_CLOCK/2))
+#error Wrong MCAN clock setting, not a whole number divider
 #endif
 
 #endif /* UC_TC37_SPEC_H */

--- a/examples/example-can-loopback/Cargo.toml
+++ b/examples/example-can-loopback/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "example-can-loopback"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+bench = false
+test = false
+
+[dependencies]
+bitflags.workspace = true
+bw-r-drivers-tc37x.workspace = true
+defmt.workspace = true
+futures.workspace = true
+pxros.workspace = true
+veecle-pxros = { workspace = true, features = ["rt"] }

--- a/examples/example-can-loopback/src/can/constants.rs
+++ b/examples/example-can-loopback/src/can/constants.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code)]
+
+pub mod peripheral_addresses {
+    //! Manually created addresses of peripheral block start addresses
+    //!
+    //! All constants starting with `MODULE` are GPIO control blocks
+    pub const MODULE_P00: u32 = 0xF003A000;
+    pub const MODULE_P01: u32 = 0xF003A100;
+    pub const MODULE_P02: u32 = 0xF003A200;
+    pub const MODULE_P10: u32 = 0xF003AA00;
+    pub const MODULE_P11: u32 = 0xF003AB00;
+    pub const MODULE_P12: u32 = 0xF003AC00;
+    pub const MODULE_P13: u32 = 0xF003AD00;
+    pub const MODULE_P14: u32 = 0xF003AE00;
+    pub const MODULE_P15: u32 = 0xF003AF00;
+    pub const MODULE_P20: u32 = 0xF003B400;
+    pub const MODULE_P21: u32 = 0xF003B500;
+    pub const MODULE_P22: u32 = 0xF003B600;
+    pub const MODULE_P23: u32 = 0xF003B700;
+    pub const MODULE_P32: u32 = 0xF003C000;
+    pub const MODULE_P33: u32 = 0xF003C100;
+    pub const MODULE_P34: u32 = 0xF003C200;
+    pub const MODULE_P40: u32 = 0xF003C800;
+    pub const SRAM_MCMCAN0: u32 = 0xF0200000;
+    pub const SFR_MCMCAN0: u32 = 0xF0208000;
+    pub const SFR_MCMCAN0_END: u32 = 0xF0209000;
+    pub const SCU_START: u32 = 0xF0036000;
+    pub const SCU_END: u32 = 0xF0036400;
+    pub const SRC_START: u32 = 0xF0038000;
+    pub const SRC_END: u32 = 0xF003A000;
+}

--- a/examples/example-can-loopback/src/can/mbx.rs
+++ b/examples/example-can-loopback/src/can/mbx.rs
@@ -1,0 +1,49 @@
+use pxros::bindings::*;
+use pxros::PxResult;
+use veecle_pxros::pxros::events::Event;
+use veecle_pxros::pxros::messages::{NewMessageEvents, RawMessage};
+
+/// Mailbox for processing CAN packets.
+#[derive(Debug, Clone, Copy)]
+pub struct CanMailbox {
+    rx_mailbox: PxMbx_t,
+}
+
+impl CanMailbox {
+    /// Initializes the mailbox.
+    pub fn init(rx_mailbox: PxMbx_t) -> Self {
+        Self { rx_mailbox }
+    }
+
+    /// Sends CAN bytes to the mailbox.
+    pub fn send(&mut self, bytes: &[u8], mailbox: PxMbx_t) -> PxResult<()> {
+        let mut handle = RawMessage::request(bytes.len() as u32, PxMc_t::default(), PxOpool_t::default())?;
+
+        // Copy the raw bytes into the message.
+        handle.data_mut()?.copy_from_slice(bytes);
+
+        // Send it to the mailbox.
+        handle.send(mailbox).map_err(|error| {
+            defmt::warn!("Error {:?} while sending message: {:?}", error, handle);
+            handle.release().expect("Could not release message");
+
+            error
+        })?;
+
+        Ok(())
+    }
+
+    /// Receives a CAN [RawMessage] or returns upon [Event].
+    ///
+    /// The function is blocking, but it allows events reception to early return
+    /// even if a message is not received.
+    pub fn receive_or_event<E: Event>(&mut self, events: E) -> PxResult<Option<RawMessage>> {
+        let events = PxEvents_t(events.bits());
+        let result = RawMessage::receive_with_events(self.rx_mailbox, events)?;
+        match result {
+            NewMessageEvents::Message(message) => Ok(Some(message)),
+            NewMessageEvents::Events(_) => Ok(None),
+            NewMessageEvents::Both((message, _)) => Ok(Some(message)),
+        }
+    }
+}

--- a/examples/example-can-loopback/src/can/mod.rs
+++ b/examples/example-can-loopback/src/can/mod.rs
@@ -1,0 +1,256 @@
+//! Task running the CAN driver.
+mod constants;
+pub mod mbx;
+
+use core::mem::MaybeUninit;
+
+use bw_r_drivers_tc37x::can::config::NodeInterruptConfig;
+use bw_r_drivers_tc37x::can::msg::ReadFrom;
+use bw_r_drivers_tc37x::can::*;
+use bw_r_drivers_tc37x::cpu::Priority;
+use bw_r_drivers_tc37x::gpio::GpioExt;
+use bw_r_drivers_tc37x::pac;
+use bw_r_drivers_tc37x::pac::can0::{Can0, N as Can0Node};
+use constants::peripheral_addresses::{
+    MODULE_P00,
+    MODULE_P34,
+    SCU_END,
+    SCU_START,
+    SFR_MCMCAN0_END,
+    SRAM_MCMCAN0,
+    SRC_END,
+    SRC_START,
+};
+use bw_r_drivers_tc37x::embedded_can::ExtendedId;
+use pxros::bindings::*;
+use pxros::mem::MemoryRegion;
+use pxros::PxResult;
+use veecle_pxros::pxros::events::Receiver;
+use veecle_pxros::pxros::name_server::TaskName;
+
+use crate::can::mbx::CanMailbox;
+
+/// Name of the server task
+pub const CAN_DRV_TASK: TaskName = TaskName::new(6);
+const CAN_DRV_TASK_PRIO: u32 = 6;
+
+bitflags::bitflags! {
+    /// Events used by the CAN task.
+    #[derive(Copy, Clone)]
+    pub struct CanDrvEvents: u32 {
+        /// A CAN packet is ready to be transmitted.
+        const TxEvent = 0b0001_0000;
+        /// A CAN packet has been received.
+        const RxEvent = 0b0000_1000;
+        /// Ticker
+        const Ticker = 0b0000_0100;
+    }
+}
+
+const CAN_REGIONS: [MemoryRegion; 4] = [
+    MemoryRegion::new(MODULE_P00..MODULE_P34, PxProtectType_t::WRProtection),
+    MemoryRegion::new(SRAM_MCMCAN0..SFR_MCMCAN0_END, PxProtectType_t::WRProtection),
+    MemoryRegion::new(SCU_START..SCU_END, PxProtectType_t::WRProtection),
+    MemoryRegion::new(SRC_START..SRC_END, PxProtectType_t::WRProtection),
+];
+
+/// Initialize CAN Module 0 Node 0
+fn setup_can0() -> Option<Node<Can0Node, Can0, Node0, Configured>> {
+    let can_module = Module::new(Module0);
+    let mut can_module = can_module.enable();
+
+    let cfg = NodeConfig {
+        baud_rate: BitTimingConfig::Auto(AutoBitTiming {
+            baud_rate: 1_000_000,
+            sample_point: 8_000,
+            sync_jump_width: 3,
+        }),
+        ..Default::default()
+    };
+
+    let node = can_module.take_node(Node0, cfg)?;
+
+    node.setup_tx(&TxConfig {
+        mode: TxMode::DedicatedBuffers,
+        dedicated_tx_buffers_number: 2,
+        fifo_queue_size: 0,
+        buffer_data_field_size: DataFieldSize::_8,
+        event_fifo_size: 1,
+        tx_event_fifo_start_address: 0x400,
+        tx_buffers_start_address: 0x440,
+    });
+
+    node.setup_pins(None);
+
+    Some(node.lock_configuration())
+}
+
+/// Initialize CAN Module 0 Node 1
+fn setup_can1() -> Option<Node<Can0Node, Can0, Node1, Configured>> {
+    let can_module = Module::new(Module0);
+    let mut can_module = can_module.enable();
+
+    let cfg = NodeConfig {
+        baud_rate: BitTimingConfig::Auto(AutoBitTiming {
+            baud_rate: 1_000_000,
+            sample_point: 8_000,
+            sync_jump_width: 3,
+        }),
+        ..Default::default()
+    };
+
+    let mut node = can_module.take_node(Node1, cfg)?;
+
+    node.setup_rx(RxConfig {
+        mode: RxMode::SharedFifo0,
+        buffer_data_field_size: DataFieldSize::_8,
+        fifo0_data_field_size: DataFieldSize::_8,
+        fifo1_data_field_size: DataFieldSize::_8,
+        fifo0_operating_mode: RxFifoMode::Blocking,
+        fifo1_operating_mode: RxFifoMode::Blocking,
+        fifo0_watermark_level: 0,
+        fifo1_watermark_level: 0,
+        fifo0_size: 4,
+        fifo1_size: 0,
+        rx_fifo0_start_address: 0x100,
+        rx_fifo1_start_address: 0x200,
+        rx_buffers_start_address: 0x300,
+    });
+
+    node.setup_pins(None);
+
+    node.setup_interrupt(&NodeInterruptConfig {
+        interrupt_group: InterruptGroup::Rxf0n,
+        interrupt: Interrupt::RxFifo0newMessage,
+        line: InterruptLine::Line0,
+        priority: Priority::try_from(6).unwrap(),
+        tos: Tos::Cpu0,
+    });
+
+    Some(node.lock_configuration())
+}
+
+/// Initialize the STB pin for the CAN transceiver.
+fn init_can_stb_pin() {
+    let gpio20 = pac::P20.split();
+    let mut stb = gpio20.p20_6.into_push_pull_output();
+    stb.set_low();
+}
+
+/// CAN RX interrupt handler
+#[no_mangle]
+pub extern "C" fn can_rx_handler(arg1: PxArg_t) {
+    let task = PxTask_t::from_raw(arg1.0 as u32);
+    let evt = CanDrvEvents::RxEvent.bits();
+
+    unsafe { PxTaskSignalEvents_Hnd(task, PxEvents_t(evt)) };
+}
+
+/// Naive task that communicates over CAN.
+#[veecle_pxros::pxros_task(auto_spawn(core = 0, priority = 8), regions = CAN_REGIONS, privileges = DirectAccess, stack_size = 24_000)]
+fn rust_task_can_drv(mailbox: PxMbx_t) -> PxResult<()> {
+    // Register the name to the name server. Will panic on error.
+    CAN_DRV_TASK.register(PxGetId());
+
+    // Initialize CAN transceiver
+    init_can_stb_pin();
+
+    // Create CAN module (needs supervisor privileges)
+    let mut can0 = MaybeUninit::<Node<Can0Node, Can0, Node0, Configured>>::uninit();
+    let can_ptr: *mut Node<Can0Node, Can0, Node0, Configured> = can0.as_mut_ptr();
+    unsafe { _PxHndcallPTR_F(Some(init_can0), can_ptr as *mut c_void) };
+    let can0 = unsafe { can0.assume_init() };
+
+    let mut can1 = MaybeUninit::<Node<Can0Node, Can0, Node0, Configured>>::uninit();
+    let can_ptr: *mut Node<Can0Node, Can0, Node0, Configured> = can1.as_mut_ptr();
+    unsafe { _PxHndcallPTR_F(Some(init_can1), can_ptr as *mut c_void) };
+    let can1 = unsafe { can1.assume_init() };
+
+    // Attach callback to interrupt handler to know when CAN packets are received.
+    let task = PxGetId().as_raw();
+    let err = unsafe { PxIntInstallFastContextHandler(CAN_DRV_TASK_PRIO, PxIntHandler_t(Some(can_rx_handler)), PxArg_t(task as i32)) };
+    PxResult::from(err).expect("Could not install fast context handler");
+
+    // Create a new mailbox to expose received CAN packets and register it as global mailbox.
+    let rx_mailbox = unsafe { PxMbxRequest(PxOpool_t::default()) }
+        .checked()
+        .expect("Could not create other mailbox");
+    let err = unsafe { PxMbxRegisterMbx(PxMbxReq_t::_PxSrv3_ReqMbxId, rx_mailbox) };
+    PxResult::from(err).expect("Could not register to global mailbox");
+
+    // Create the CAN RX mailbox.
+    let mut can_rx = CanMailbox::init(rx_mailbox);
+
+    // TODO: hardcoded ID
+    let tx_msg_id: MessageId = {
+        let id = 0x0CFE6E00;
+        let id: ExtendedId = ExtendedId::new(id).unwrap().into();
+        id.into()
+    };
+
+    // Allocate buffers for message data
+    let mut tx_msg_data: [u8; 8] = Default::default();
+    let mut rx_msg_data: [u8; 8] = Default::default();
+
+    // Obtain a receiver for *all* possible events
+    let mut receiver = Receiver::new(mailbox, CanDrvEvents::all());
+
+    loop {
+        let (events, message) = receiver.receive();
+
+        if !(events & CanDrvEvents::RxEvent).is_empty() {
+            defmt::trace!("CAN message received");
+            can1.receive(ReadFrom::RxFifo0, &mut rx_msg_data);
+            can1.clear_interrupt_flag(Interrupt::RxFifo0newMessage);
+
+            // Send received message to global mailbox
+            can_rx.send(&rx_msg_data, rx_mailbox)?;
+        }
+
+        if let Some(mut message) = message {
+            // Copy eight bytes from received private mailbox message
+            tx_msg_data.copy_from_slice(&message.data().expect("Message should contain data.")[0..8]);
+
+            // Create and transmit CAN frame
+            let tx_frame = Frame::new(tx_msg_id, tx_msg_data.as_slice()).unwrap();
+            if can0.transmit(&tx_frame).is_err() {
+                defmt::info!("Cannot send frame");
+            }
+
+            // Finally, release the message.
+            message.release().expect("Failed to release message.");
+        }
+    }
+}
+
+use core::ffi::c_void;
+
+/// Wrapper for calling setup_can0 with supervisor privileges
+extern "C" fn init_can0(ptr: *mut c_void) -> i32 {
+    let ptr = ptr as *mut Node<Can0Node, Can0, Node0, Configured>;
+    let can: &mut Node<Can0Node, Can0, Node0, Configured> = unsafe { &mut *ptr };
+    *can = match setup_can0() {
+        Some(can) => can,
+        None => {
+            defmt::info!("Can initialization error");
+            loop {}
+        },
+    };
+
+    return 0;
+}
+
+/// Wrapper for calling setup_can0 with supervisor privileges
+extern "C" fn init_can1(ptr: *mut c_void) -> i32 {
+    let ptr = ptr as *mut Node<Can0Node, Can0, Node1, Configured>;
+    let can: &mut Node<Can0Node, Can0, Node1, Configured> = unsafe { &mut *ptr };
+    *can = match setup_can1() {
+        Some(can) => can,
+        None => {
+            defmt::info!("Can initialization error");
+            loop {}
+        },
+    };
+
+    return 0;
+}

--- a/examples/example-can-loopback/src/lib.rs
+++ b/examples/example-can-loopback/src/lib.rs
@@ -1,0 +1,118 @@
+//! Embedded world demo code - see README.md for details
+#![no_std]
+mod can;
+
+use core::time::Duration;
+
+use pxros::bindings::*;
+use pxros::PxResult;
+use veecle_pxros::pxros::events::Event;
+use veecle_pxros::pxros::messages::MailSender;
+use veecle_pxros::pxros::ticker::Ticker;
+
+use crate::can::mbx::CanMailbox;
+use crate::can::{CanDrvEvents, CAN_DRV_TASK};
+
+bitflags::bitflags! {
+    /// Events for the CAN.
+    #[derive(Copy, Clone)]
+    pub struct CanEvents: u32 {
+        const Ticker = 0b0001_0000;
+    }
+}
+
+/// Entry point
+#[veecle_pxros::pxros_task(auto_spawn(core = 0, priority = 12))]
+fn rust_task_can(_mailbox: PxMbx_t) -> PxResult<()> {
+
+    let can_drv_task = CAN_DRV_TASK.query(CanDrvEvents::TxEvent);
+    
+    // Get a mailbox sender for CAN Tx
+    let mut sender = MailSender::new(can_drv_task)?;
+
+    // Wait for the CAN service to initialize.
+    let rx_mailbox = Service::Can
+        .wait_for_service(PXCORE_0, CanEvents::Ticker)
+        .expect("The CAN service should be queryable within ten tries.");
+
+    let _ticker = Ticker::every(CanEvents::Ticker, Duration::from_millis(1000)).unwrap();
+
+    // This transmits over private mailbox and receives over service mailbox.
+    let mut can = CanMailbox::init(rx_mailbox);
+
+    let mut tx_msg_data: [u8; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
+
+    loop {
+        match can.receive_or_event(CanEvents::Ticker) {
+            Ok(None) => {
+                // Transmit a different message each time (changing the first byte)
+                tx_msg_data[0] = tx_msg_data[0].wrapping_add(1);
+
+                // Ticker event. Trigger the sending of CAN packet.
+                if let Err(e) = sender.send_bytes(tx_msg_data.as_slice()) {
+                    defmt::warn!("Message error: {:?}", e)
+                } else {
+                    defmt::trace!("Message sent")
+                }
+            },
+            Ok(Some(mut message)) => {
+                // Message received. Deserialize payload and work with it.
+                defmt::info!("Received CAN message: {:?}", message);
+
+                // Copy received message to output
+                tx_msg_data.copy_from_slice(&message.data().expect("Message should contain data.")[0..8]);
+
+                message.release()?;
+            },
+            Err(error) => {
+                // Just print the error.
+                defmt::info!("Error while receiving CAN message: {:?}", error);
+            },
+        }
+    }
+}
+
+/// Small semantic wrapper for declaring global PXROS services.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, defmt::Format)]
+pub enum Service {
+    /// The Ethernet driver service.
+    Ethernet,
+    /// The Network service.
+    Network,
+    /// The CAN serive.
+    Can,
+}
+
+impl Service {
+    /// Queries for a service up to ten time until available; returns error otherwise.
+    ///
+    /// This requires a *ticker* event for the duration of the query to support
+    /// delays: this is needed to allow for other work on the same core to complete.
+    pub fn wait_for_service<E: Event>(&self, core: u32, event: E) -> PxResult<PxMbx_t> {
+        let timeout = Duration::from_millis(100);
+        let mut ticker = Ticker::every(event, timeout)?;
+
+        let service = match self {
+            Service::Ethernet => PxMbxReq_t::_PxSrv1_ReqMbxId,
+            Service::Network => PxMbxReq_t::_PxSrv2_ReqMbxId,
+            Service::Can => PxMbxReq_t::_PxSrv3_ReqMbxId,
+        };
+        let core = PxCoreId_t(PxUChar_t(core as u8));
+
+        // Up to one second.
+        for _ in 0..10 {
+            let err = unsafe { PxGetGlobalServerMbx(core, service) };
+            match err {
+                PxError_t::PXERR_REQUEST_FAILED => break,
+                PxError_t::PXERR_NOERROR => {
+                    return Ok(unsafe { PxMbxRequestMbx(service) });
+                },
+                _ => {},
+            }
+
+            ticker.wait();
+        }
+
+        Err(PxError_t::PXERR_REQUEST_FAILED)
+    }
+}

--- a/task-macro/src/task.rs
+++ b/task-macro/src/task.rs
@@ -152,7 +152,7 @@ pub fn run(function: TokenStream, arguments: TokenStream) -> Result<TokenStream,
                     ts_context: PxTaskContext_ct(&TASK_CONTEXT as *const _),
                     ts_protect_region: PxProtectRegion_ct(&TASK_REGIONS[0] as *const _),
                     ts_privileges: PxArg_t(Privileges::#privileges as i32),
-                    ts_accessrights: 0,
+                    ts_accessrights: PXACCESS_HANDLERS | PXACCESS_INSTALL_HANDLERS,
                     // Priority/scheduling
                     ts_prio: prio,
                     ts_timeslices: PxTicks_t(0),


### PR DESCRIPTION
Adding CAN loopback example, #1 
Two tasks are created:
* rust_task_can_drv interfaces with the Rust CAN driver, it exposes received messages to global mailbox 3 and receives over private mailbox a message to be transmitted.
* rust_task_can interacts with rust_task_can_drv by sending/receiving messages through mailboxes.
