### PR TITLE
Add option to include the Ethernet driver task.

### DIFF
--- a/app-tc37x/CMakeLists.txt
+++ b/app-tc37x/CMakeLists.txt
@@ -11,6 +11,11 @@ cmake_path(SET pxros_utils_dir  NORMALIZE $ENV{PXROS_UTILS})
 cmake_path(SET illd_base        NORMALIZE $ENV{ILLD_BASE})
 cmake_path(SET illd_precompiled NORMALIZE $ENV{ILLD_PRECOMPILED})
 
+# Whether to include the ethernet driver task.
+if (DEFINED ENV{INCLUDE_ETHERNET_DRIVER_TASK})
+    add_compile_definitions(INCLUDE_ETHERNET_DRIVER_TASK)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()

--- a/app-tc37x/pxros/tasks/taskDeployment.c
+++ b/app-tc37x/pxros/tasks/taskDeployment.c
@@ -24,9 +24,13 @@
 /* Task Deployment Table
  * Task configuration relying on Task default Memory Class and Object pool
  */
+#ifdef INCLUDE_ETHERNET_DRIVER_TASK
 const task_deployment_t taskTable[] = {
     { PxEthTaskCreate, GETH_DRIVER_PRIO, PXCORE_0},
 };
+#else
+const task_deployment_t taskTable[] = {};
+#endif
 
 /* FUNTION: TaskDeploy
  *     Function calls Task Create function according their core assignment in the taskTable


### PR DESCRIPTION
Before, we included the Ethernet driver task in every example, which broke some of them. This change makes this optional and configurable through xtask.