### PR TITLE
Update tricore-probe installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ Next, **CMake** is used to compile the PXROS kernel and C tasks defined in the *
 
 2. Install HighTec's [Rust](https://hightec-rt.com/en/rust-evaluation) compiler toolchain. Register and follow their installation instruction.
 
-3. If on Windows, install Infineon's [DAS and MEMTOOL](https://www.infineon.com/cms/en/tools/aurix-tools/free-tools/infineon): these tools are required to utilize [tricore-probe](https://github.com/veecle/tricore-probe). If you are using Linux, please follow the guidelines provided in the repository.
+3. If on Windows, install Infineon's [DAS](https://www.infineon.com/cms/en/tools/aurix-tools/free-tools/infineon) and [AurixFlasher](https://softwaretools.infineon.com/tools/com.ifx.tb.tool.aurixflashersoftwaretool): these tools are required to utilize [tricore-probe](https://github.com/veecle/tricore-probe).
+If you are using Linux, please follow the guidelines provided in the [tricore-probe](https://github.com/veecle/tricore-probe) repository.
 
-4. Install **tricore-probe** via `cargo +nightly install --git https://github.com/veecle/tricore-probe tricore-probe`. Make sure the listed requirements are installed.
+4. Install **tricore-probe** via `cargo install tricore-probe --git https://github.com/veecle/tricore-probe --version 0.2.0`.
+Make sure the listed requirements are installed.
 
 For additional installation instructions or troubleshooting please also visit [Bluewind's repository](https://github.com/bluewind-embedded-systems/bw-r-drivers-tc37x).
 


### PR DESCRIPTION
This should be merged after https://github.com/veecle/tricore-probe/pull/27.